### PR TITLE
Revert "optmize decoder&&topk"

### DIFF
--- a/libs/layers/lstm.py
+++ b/libs/layers/lstm.py
@@ -334,7 +334,7 @@ def param_init_lstm_cond(O, params, prefix='lstm_cond', nin=None, dim=None, dimc
     return params
 
 
-def lstm_cond_layer(P, state_below, O, prefix='lstm', mask=None, context=None, one_step=False, init_memory=None, projected_context=None,
+def lstm_cond_layer(P, state_below, O, prefix='lstm', mask=None, context=None, one_step=False, init_memory=None,
                     init_state=None, context_mask=None, **kwargs):
     """Conditional LSTM layer with attention
 
@@ -371,7 +371,7 @@ def lstm_cond_layer(P, state_below, O, prefix='lstm', mask=None, context=None, o
     if init_state is None:
         init_state = T.alloc(0., n_samples, dim)
 
-    #projected_context = T.dot(context, P[_p(prefix, 'Wc_att', layer_id)]) + P[_p(prefix, 'b_att', layer_id)]
+    projected_context = T.dot(context, P[_p(prefix, 'Wc_att', layer_id)]) + P[_p(prefix, 'b_att', layer_id)]
 
     # Projected x
     if multi:

--- a/libs/models/model.py
+++ b/libs/models/model.py
@@ -13,7 +13,6 @@ import os
 import copy
 
 import bottleneck
-import numexpr as ne
 import theano
 import theano.tensor as T
 import numpy as np
@@ -560,12 +559,6 @@ class NMTModel(object):
         f_init = theano.function(inps, outs, name='f_init', profile=profile)
         print('Done')
 
-
-        pre_projected_context_ = self.attention_projected_context(ctx, prefix='decoder')
-        f_att_projected = theano.function([ctx], pre_projected_context_, name='f_att_projected', profile=profile)
-
-
-
         # x: 1 x 1
         y = T.vector('y_sampler', dtype='int64')
         init_state = T.tensor3('init_state', dtype=fX)
@@ -575,17 +568,14 @@ class NMTModel(object):
         emb = T.switch(y[:, None] < 0,
                        T.alloc(0., 1, self.P['Wemb_dec'].shape[1]),
                        self.P['Wemb_dec'][y])
-        projected_context1 = T.tensor3('projected_context1', dtype=fX)
 
         # Apply one step of conditional gru with attention
         hidden_decoder, context_decoder, _, kw_ret = self.decoder(
-            emb, y_mask=None, init_state=init_state, context=ctx, projected_context=projected_context1,
+            emb, y_mask=None, init_state=init_state, context=ctx,
             x_mask=x_mask if batch_mode else None,
             dropout_params=dropout_params, one_step=True, init_memory=init_memory,
             get_gates=get_gates,
         )
-
-
 
         # Get memory_out and hiddens_without_dropout
         # FIXME: stack list into a single tensor
@@ -613,7 +603,7 @@ class NMTModel(object):
         # Compile a function to do the whole thing above, next word probability,
         # sampled word for the next target, next hidden state to be used
         print('Building f_next..', end='')
-        inps = [y, ctx, projected_context1, init_state]
+        inps = [y, ctx, init_state]
         if batch_mode:
             inps.insert(2, x_mask)
         outs = [next_probs, next_sample, hiddens_without_dropout]
@@ -632,7 +622,7 @@ class NMTModel(object):
         f_next = theano.function(inps, outs, name='f_next', profile=profile)
         print('Done')
 
-        return f_init, [f_next, f_att_projected]
+        return f_init, f_next
 
     def gen_sample(self, f_init, f_next, x, trng=None, k=1, maxlen=30,
                    stochastic=True, argmax=False, **kwargs):
@@ -804,28 +794,24 @@ class NMTModel(object):
         next_w = np.array([-1] * batch_size, dtype='int64')  # bos indicator
         next_state = np.tile(next_state[None, :, :], (self.O['n_decoder_layers'], 1, 1))
         next_memory = np.zeros((self.O['n_decoder_layers'], next_state.shape[1], next_state.shape[2]), dtype=fX)
-        ctx = np.repeat(ctx0, lives_k, axis=1)
-        projected_context_ = f_next[1](ctx)
 
         for ii in xrange(maxlen):
             ctx = np.repeat(ctx0, lives_k, axis=1)
-            p_context_ = np.repeat(projected_context_, lives_k, axis=1)
             x_extend_masks = np.repeat(x_mask, lives_k, axis=1)
             cursor_start, cursor_end = 0, lives_k[0]
             for jj in xrange(batch_size):
                 if lives_k[jj] > 0:
                     ctx[:, cursor_start: cursor_end, :] = np.repeat(ctx0[:, jj, :][:, None, :], lives_k[jj], axis=1)
-                    p_context_[:, cursor_start: cursor_end, :] = np.repeat(projected_context_[:, jj, :][:, None, :], lives_k[jj], axis=1)
                     x_extend_masks[:, cursor_start: cursor_end] = np.repeat(x_mask[:, jj][:, None], lives_k[jj], axis=1)
                 if jj < batch_size - 1:
                     cursor_start = cursor_end
                     cursor_end += lives_k[jj + 1]
 
-            inps = [next_w, ctx, x_extend_masks, p_context_, next_state]
+            inps = [next_w, ctx, x_extend_masks, next_state]
             if 'lstm' in unit:
                 inps.append(next_memory)
 
-            ret = f_next[0](*inps)
+            ret = f_next(*inps)
 
             if 'lstm' in unit:
                 next_memory = ret[3]
@@ -846,8 +832,7 @@ class NMTModel(object):
                         cursor_end += lives_k[jj + 1]
                     continue
                 index_range = range(cursor_start, cursor_end)
-                tmp = next_p[index_range, :]
-                cand_scores = batch_hyp_scores[jj][:, None] - ne.evaluate('log(tmp)')
+                cand_scores = batch_hyp_scores[jj][:, None] - np.log(next_p[index_range, :])
                 cand_flat = cand_scores.flatten()
 
                 try:
@@ -1142,7 +1127,7 @@ class NMTModel(object):
 
         return context, kw_ret
 
-    def decoder(self, tgt_embedding, y_mask, init_state, context, x_mask, projected_context, 
+    def decoder(self, tgt_embedding, y_mask, init_state, context, x_mask,
                 dropout_params=None, one_step=False, init_memory=None, **kwargs):
         """Multi-layer GRU decoder.
 
@@ -1280,7 +1265,7 @@ class NMTModel(object):
                     inputs.append(outputs[-1])
 
             hidden_decoder, context_decoder, alpha_decoder, kw_ret_att = get_build(unit + '_cond')(
-                self.P, inputs[-1], self.O, prefix='decoder', mask=y_mask, context=context, projected_context=projected_context, 
+                self.P, inputs[-1], self.O, prefix='decoder', mask=y_mask, context=context,
                 context_mask=x_mask, one_step=one_step, init_state=init_state[attention_layer_id],
                 dropout_params=dropout_params, layer_id=attention_layer_id, init_memory=init_memory[attention_layer_id],
                 get_gates=get_gates, unit_size=unit_size,
@@ -1399,11 +1384,6 @@ class NMTModel(object):
         for k, v in np.load(load_filename).iteritems():
             if k in self.P:
                 self.P[k].set_value(v)
-
-    def attention_projected_context(self, context, prefix='lstm', **kwargs):
-        attention_layer_id = self.O['attention_layer_id']
-        pre_projected_context_ = T.dot(context, self.P[_p(prefix, 'Wc_att', attention_layer_id)]) + self.P[_p(prefix, 'b_att', attention_layer_id)]
-        return pre_projected_context_
 
 
 __all__ = [


### PR DESCRIPTION
Temporarily reverts fyabc/DL4NMT_Theano#4

There are problems in training. The build_model should be modified, otherwise there are errors as:

Traceback (most recent call last):
  File "train_nmt.py", line 300, in <module>
    main()
  File "train_nmt.py", line 295, in main
    fine_tune_type= args.finetune_type,
  File "/home/fetia/DL4NMT_Theano/libs/nmt.py", line 266, in train
    cost, test_cost, x_emb = model.build_model()
  File "/home/fetia/DL4NMT_Theano/libs/models/model.py", line 425, in build_model
    dropout_params=dropout_params, one_step=False,
TypeError: decoder() takes at least 7 arguments (8 given)
